### PR TITLE
Update HVSinicization.js

### DIFF
--- a/HVSinicization.js
+++ b/HVSinicization.js
@@ -550,6 +550,9 @@ function start_observe() {
 
 if (document.querySelector('#battle_main') !== null) {
   // 新回合开始时会刷新 battle_main，导致原本的监听失效，必须在刷新时重新监听一次
+  observe_node(document.querySelector('#battle_main'), { childList: true }, () => {
+    start_observe();
+  });
   observe_node(document.querySelector('body'), { childList: true }, () => {
     start_observe();
   });


### PR DESCRIPTION
撤销了 c0ab86bebb07f017fea0f5e260f7112342bc1fb3 的部分更改

看到你提交了一个新问题，大概是由于我的更改造成的
注释里写了 `// 新回合开始时会刷新 battle_main，导致原本的监听失效，必须在刷新时重新监听一次`
但是据我所知Monsterbation在新回合开始时只刷新body，为了避免资源浪费所以删掉了这部分battle_main的监听
现在看删掉了这个部分导致你可能漏翻译可能你是使用了什么别的脚本会在新回合时只刷新部分框体，所以总之把这部分添加回去了，至于能不能解决问题就不知道了。
重复翻译应该是不会再发生，避免重复翻译的代码只有没撤销的一行